### PR TITLE
added the logic for reverse catchup when the leader has a lower times…

### DIFF
--- a/db-manager/leader.go
+++ b/db-manager/leader.go
@@ -53,6 +53,14 @@ func monitorLeader(db *gorm.DB) {
 			log.Printf("leader heartbeat is newer than mine (%v > %v)\n", heartbeat.Timestamp, timestamp)
 			catchup(timestamp)
 		}
+
+		if heartbeat.Timestamp < timestamp {
+			log.Printf("my timestamp is newer than leader's (%v < %v), initiating reverse catchup",
+				heartbeat.Timestamp, timestamp)
+			if err := reverseLeaderCatchup(db, allConfigs[leaderIndex].Address); err != nil {
+				log.Printf("reverse catchup failed: %s", err)
+			}
+		}
 	}
 }
 
@@ -108,7 +116,70 @@ func catchup(myTimestamp int) {
 		}
 		log.Printf("self acked\n")
 	}
+}
 
+func reverseLeaderCatchup(db *gorm.DB, leaderAddress string) error {
+	timestamp := getTimestamp(db)
+
+	// Get leader's timestamp first
+	client := &http.Client{Timeout: time.Second * 2}
+	resp, err := client.Get(fmt.Sprintf("http://%s/api/v1/heartbeat", leaderAddress))
+	if err != nil {
+		return fmt.Errorf("failed to contact leader: %s", err)
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading response: %s", err)
+	}
+
+	var leaderHeartbeat types.Heartbeat
+	err = json.Unmarshal(respBytes, &leaderHeartbeat)
+	if err != nil {
+		return fmt.Errorf("error parsing heartbeat: %s", err)
+	}
+
+	// If my timestamp is higher than leader's, initiate reverse catchup
+	if timestamp > leaderHeartbeat.Timestamp {
+		log.Printf("My timestamp (%d) is higher than leader's (%d), initiating reverse catchup",
+			timestamp, leaderHeartbeat.Timestamp)
+
+		// Query manifests that the leader is missing
+		var manifests []types.Manifest
+		err = db.Where("timestamp > ?", leaderHeartbeat.Timestamp).Find(&manifests).Error
+		if err != nil {
+			return fmt.Errorf("error querying newer manifests: %s", err)
+		}
+
+		log.Printf("Sending %d manifests to leader for reverse catchup", len(manifests))
+
+		// Send these manifests to the leader via the reverse catchup endpoint
+		manifestsBytes, err := json.Marshal(manifests)
+		if err != nil {
+			return fmt.Errorf("error serializing manifests: %s", err)
+		}
+
+		resp, err := client.Post(
+			fmt.Sprintf("http://%s/api/v1/reverse-catchup", leaderAddress),
+			"application/json",
+			bytes.NewBuffer(manifestsBytes),
+		)
+		if err != nil {
+			return fmt.Errorf("error sending manifests to leader: %s", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			respBytes, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("leader rejected reverse catchup: %s: %s",
+				resp.Status, string(respBytes))
+		}
+
+		log.Printf("Reverse catchup to leader successful")
+	}
+
+	return nil
 }
 
 func election() {
@@ -149,7 +220,7 @@ func election() {
 	highestTimestamp := int(0)
 	highestIndex := cfg.Index
 	for nodeIndex, timestamp := range timestamps {
-		if timestamp > highestTimestamp { // the node with higher timestamp wins 
+		if timestamp > highestTimestamp { // the node with higher timestamp wins
 			highestTimestamp = timestamp
 			highestIndex = nodeIndex
 		} else if timestamp == highestTimestamp {

--- a/db-manager/main.go
+++ b/db-manager/main.go
@@ -44,6 +44,7 @@ func main() {
 	http.HandleFunc("/api/"+cfg.Version+"/election/", electionHandler)
 	http.HandleFunc("/api/"+cfg.Version+"/leader", leaderHandler)
 	http.HandleFunc("/api/"+cfg.Version+"/catchup", catchupHandler(db))
+	http.HandleFunc("/api/"+cfg.Version+"/reverse-catchup", reverseCatchupHandler(db))
 
 	log.Printf("Node %d serving on %s...\n", cfg.Index, cfg.Address)
 	err = http.ListenAndServe(cfg.Address, nil)

--- a/db-manager/srv.go
+++ b/db-manager/srv.go
@@ -277,3 +277,53 @@ func catchupHandler(db *gorm.DB) func(http.ResponseWriter, *http.Request) {
 		log.Printf("sent %d manifests to %d\n", len(manifests), requesterIndex)
 	}
 }
+
+func reverseCatchupHandler(db *gorm.DB) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Only leaders should accept reverse catchup
+		if leaderIndex != cfg.Index {
+			http.Error(w, "Not the leader", http.StatusBadRequest)
+			return
+		}
+
+		if r.Method != http.MethodPost {
+			http.Error(w, "Only POST is allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var manifests []types.Manifest
+		err := json.NewDecoder(r.Body).Decode(&manifests)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid request: %s", err.Error()), http.StatusBadRequest)
+			return
+		}
+
+		log.Printf("Received reverse catchup with %d manifests from a follower with newer data", len(manifests))
+
+		// Process each manifest
+		successCount := 0
+		for _, manifest := range manifests {
+			// Check if manifest already exists
+			existingManifest, err := querySingleManifest(db, manifest.Name)
+			if err == nil && existingManifest.Timestamp >= manifest.Timestamp {
+				// Skip if we already have equal or newer data
+				continue
+			}
+
+			// Insert or update the manifest in our database
+			result := db.Save(&manifest)
+			if result.Error != nil {
+				log.Printf("Error saving manifest %s during reverse catchup: %s", 
+					manifest.Name, result.Error)
+				continue
+			}
+			successCount++
+		}
+
+		log.Printf("Reverse catchup complete: processed %d/%d manifests", successCount, len(manifests))
+		w.WriteHeader(http.StatusOK)
+		if _, err := fmt.Fprintf(w, "Successfully processed %d manifests", successCount); err != nil {
+			log.Printf("Error writing response: %s", err)
+		}
+	}
+}

--- a/superconfig.json
+++ b/superconfig.json
@@ -11,6 +11,24 @@
       "pg-user": "postgres",
       "pg-password": "password",
       "pg-port": "5432"
+    },
+    {
+      "index": 1,
+      "address": "localhost:8081",
+      "version": "v1",
+      "pg-host": "localhost",
+      "pg-user": "postgres",
+      "pg-password": "password",
+      "pg-port": "5432"
+    },
+    {
+      "index": 2,
+      "address": "localhost:8082",
+      "version": "v1",
+      "pg-host": "localhost",
+      "pg-user": "postgres",
+      "pg-password": "password",
+      "pg-port": "5432"
     }
   ]
 }


### PR DESCRIPTION
1. Spin up three db manager nodes, with node 0 being elected as the leader;
2. Run `curl -X POST -H "Content-Type: application/json" -d @test_manifest.json http://localhost:8082/api/v1/manifests` to simulate a network partition where reverse proxy sees node 3 as the leader and sends some write request to it;

**Original Behavior:**
Perform another write request via UI and we see the request routed to node 0 whereas in fact node 2 currently has a larger timestamp;

**Current Behavior:**
Node 0 detects that node 2 has a larger timestamp thus a reverse catchup will happen to request catchup from node 2. A catchup will then happen from node 0 to 1 and at this moment, all of the data is consistent.

![CleanShot 2025-04-15 at 11 13 47](https://github.com/user-attachments/assets/000137f6-f4e5-4965-81fb-bb1db56d6da3)
